### PR TITLE
Add contains() method in binary heap

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/BinaryHeap.java
+++ b/gdx/src/com/badlogic/gdx/utils/BinaryHeap.java
@@ -50,7 +50,29 @@ public class BinaryHeap<T extends BinaryHeap.Node> {
 		node.value = value;
 		return add(node);
 	}
-
+	
+	/** Returns if binary heap contains the provided node.
+	* @param node - may be null
+	* @param identity - if true, == is used. Otherwise, .equals is used
+	*/
+	public boolean contains (T node, boolean identity) {
+		if (identity || node == null) {
+			for (Node n : nodes) {
+				if (n == node) {
+					return true;
+				}
+			}
+		} else {
+			for (Node n : nodes) {
+				if (n.equals(node)) {
+					return true;
+				}
+			}
+		}
+		
+		return false;
+	}
+	
 	public T peek () {
 		if (size == 0) throw new IllegalStateException("The heap is empty.");
 		return (T)nodes[0];


### PR DESCRIPTION
I believe having a .contains() method would be very useful for a binary heap. Given it runs in linear time and does not affect any other operations, I believe it would be a useful addition to the collection. I've personally have found a need for it in my game.